### PR TITLE
Events filtering by host/serverId logic

### DIFF
--- a/rook-api/src/main/java/com/github/shyiko/rook/api/event/DeleteRowsReplicationEvent.java
+++ b/rook-api/src/main/java/com/github/shyiko/rook/api/event/DeleteRowsReplicationEvent.java
@@ -24,12 +24,12 @@ import java.util.List;
  */
 public class DeleteRowsReplicationEvent extends RowsMutationReplicationEvent<List<Serializable[]>> {
 
-    public DeleteRowsReplicationEvent(String database, String table, List<Serializable[]> rows) {
-        super(database, table, rows);
+    public DeleteRowsReplicationEvent(long hostId, String database, String table, List<Serializable[]> rows) {
+        super(hostId, database, table, rows);
     }
 
-    public DeleteRowsReplicationEvent(String database, String table, Serializable[] row) {
-        super(database, table, Arrays.asList(new Serializable[][] {row}));
+    public DeleteRowsReplicationEvent(long hostId, String database, String table, Serializable[] row) {
+        super(hostId, database, table, Arrays.asList(new Serializable[][] {row}));
     }
 
     @Override

--- a/rook-api/src/main/java/com/github/shyiko/rook/api/event/InsertRowsReplicationEvent.java
+++ b/rook-api/src/main/java/com/github/shyiko/rook/api/event/InsertRowsReplicationEvent.java
@@ -24,12 +24,12 @@ import java.util.List;
  */
 public class InsertRowsReplicationEvent extends RowsMutationReplicationEvent<List<Serializable[]>> {
 
-    public InsertRowsReplicationEvent(String database, String table, List<Serializable[]> rows) {
-        super(database, table, rows);
+    public InsertRowsReplicationEvent(long hostId, String database, String table, List<Serializable[]> rows) {
+        super(hostId, database, table, rows);
     }
 
-    public InsertRowsReplicationEvent(String database, String table, Serializable[] row) {
-        super(database, table, Arrays.asList(new Serializable[][]{row}));
+    public InsertRowsReplicationEvent(long hostId, String database, String table, Serializable[] row) {
+        super(hostId, database, table, Arrays.asList(new Serializable[][]{row}));
     }
 
     @Override

--- a/rook-api/src/main/java/com/github/shyiko/rook/api/event/RowsMutationReplicationEvent.java
+++ b/rook-api/src/main/java/com/github/shyiko/rook/api/event/RowsMutationReplicationEvent.java
@@ -23,11 +23,13 @@ import java.util.Collection;
  */
 public abstract class RowsMutationReplicationEvent<T extends Collection> implements ReplicationEvent {
 
+    protected final long serverId;
     protected final String schema;
     protected final String table;
     protected final T rows;
 
-    protected RowsMutationReplicationEvent(String schema, String table, T rows) {
+    protected RowsMutationReplicationEvent(long hostId, String schema, String table, T rows) {
+        this.serverId = hostId;
         this.schema = schema;
         this.table = table;
         this.rows = rows;
@@ -43,5 +45,9 @@ public abstract class RowsMutationReplicationEvent<T extends Collection> impleme
 
     public T getRows() {
         return rows;
+    }
+
+    public long getServerId() {
+        return serverId;
     }
 }

--- a/rook-api/src/main/java/com/github/shyiko/rook/api/event/UpdateRowsReplicationEvent.java
+++ b/rook-api/src/main/java/com/github/shyiko/rook/api/event/UpdateRowsReplicationEvent.java
@@ -27,15 +27,15 @@ import java.util.Map;
 public class UpdateRowsReplicationEvent extends RowsMutationReplicationEvent<List<Map.Entry<Serializable[],
         Serializable[]>>> {
 
-    public UpdateRowsReplicationEvent(String database, String table, List<Map.Entry<Serializable[],
+    public UpdateRowsReplicationEvent(long hostId, String database, String table, List<Map.Entry<Serializable[],
             Serializable[]>> rows) {
-        super(database, table, rows);
+        super(hostId, database, table, rows);
     }
 
     @SuppressWarnings("unchecked")
-    public UpdateRowsReplicationEvent(String database, String table, Serializable[] previousValues,
+    public UpdateRowsReplicationEvent(long hostId, String database, String table, Serializable[] previousValues,
             Serializable[] values) {
-        super(database, table, Arrays.<Map.Entry<Serializable[], Serializable[]>>asList(
+        super(hostId, database, table, Arrays.<Map.Entry<Serializable[], Serializable[]>>asList(
             new AbstractMap.SimpleEntry<Serializable[], Serializable[]>(previousValues, values)));
     }
 

--- a/rook-target-hibernate4-cache/src/main/java/com/github/shyiko/rook/target/hibernate4/cache/AbstractCacheSynchronizer.java
+++ b/rook-target-hibernate4-cache/src/main/java/com/github/shyiko/rook/target/hibernate4/cache/AbstractCacheSynchronizer.java
@@ -78,6 +78,6 @@ public abstract class AbstractCacheSynchronizer implements ReplicationEventListe
         throw new UnsupportedOperationException("Unexpected " + event.getClass());
     }
 
-    protected abstract void processTX(Collection<RowsMutationReplicationEvent> events);
+    protected abstract void processTX(Collection<RowsMutationReplicationEvent> txEvents);
 
 }

--- a/rook-target-hibernate4-cache/src/main/java/com/github/shyiko/rook/target/hibernate4/cache/SecondLevelCacheSynchronizer.java
+++ b/rook-target-hibernate4-cache/src/main/java/com/github/shyiko/rook/target/hibernate4/cache/SecondLevelCacheSynchronizer.java
@@ -38,8 +38,8 @@ public class SecondLevelCacheSynchronizer extends AbstractCacheSynchronizer {
         }
     }
 
-    protected void processTX(Collection<RowsMutationReplicationEvent> events) {
-        for (RowsMutationReplicationEvent event : events) {
+    protected void processTX(Collection<RowsMutationReplicationEvent> txEvents) {
+        for (RowsMutationReplicationEvent event : txEvents) {
             Cache cache = synchronizationContext.getSessionFactory().getCache();
             String qualifiedName = event.getSchema().toLowerCase() + "." + event.getTable().toLowerCase();
 

--- a/rook-target-hibernate4-cache/src/test/java/com/github/shyiko/rook/target/hibernate/cache/SecondLevelCacheSynchronizerTest.java
+++ b/rook-target-hibernate4-cache/src/test/java/com/github/shyiko/rook/target/hibernate/cache/SecondLevelCacheSynchronizerTest.java
@@ -65,7 +65,7 @@ public class SecondLevelCacheSynchronizerTest extends AbstractHibernateTest {
                 assertTrue(cache.containsEntity(EntityWithCompositeKey.class, firstEntityKey));
                 SecondLevelCacheSynchronizer secondLevelCacheSynchronizer =
                         new SecondLevelCacheSynchronizer(synchronizationContext);
-                secondLevelCacheSynchronizer.onEvent(new DeleteRowsReplicationEvent("rook", "entity_with_cpk",
+                secondLevelCacheSynchronizer.onEvent(new DeleteRowsReplicationEvent(0, "rook", "entity_with_cpk",
                         new Serializable[] {2L, 1L}));
                 assertFalse(cache.containsEntity(EntityWithCompositeKey.class, firstEntityKey));
                 assertTrue(cache.containsEntity(EntityWithCompositeKey.class, secondEntityKey));
@@ -111,14 +111,14 @@ public class SecondLevelCacheSynchronizerTest extends AbstractHibernateTest {
                 assertTrue(cache.containsEntity(Entity.class, ENTITY_ID));
                 SecondLevelCacheSynchronizer secondLevelCacheSynchronizer =
                         new SecondLevelCacheSynchronizer(synchronizationContext);
-                secondLevelCacheSynchronizer.onEvent(new DeleteRowsReplicationEvent("rook", "entity",
+                secondLevelCacheSynchronizer.onEvent(new DeleteRowsReplicationEvent(0, "rook", "entity",
                         new Serializable[] {ENTITY_ID}));
                 assertFalse(cache.containsEntity(Entity.class, ENTITY_ID));
 
                 assertTrue(cache.containsCollection(Entity.class.getName() + ".properties", ENTITY_ID));
 
                 // entity_property table structure [id, name, value, entity_id]
-                secondLevelCacheSynchronizer.onEvent(new DeleteRowsReplicationEvent("rook", "entity_property",
+                secondLevelCacheSynchronizer.onEvent(new DeleteRowsReplicationEvent(0, "rook", "entity_property",
                         new Serializable[]{null, null, null, ENTITY_ID}));
 
                 assertFalse(cache.containsCollection(Entity.class.getName() + ".properties", ENTITY_ID));

--- a/supplement/integration-testing/hibernate4-cache-over-mysql/src/test/java/com/github/shyiko/rook/it/h4com/model/IgnoredEntity.java
+++ b/supplement/integration-testing/hibernate4-cache-over-mysql/src/test/java/com/github/shyiko/rook/it/h4com/model/IgnoredEntity.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Igor Grunskiy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.shyiko.rook.it.h4com.model;
+
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+/**
+ * @author <a href="mailto:igor.grunskiy@lifestreetmedia.com">Igor Grunskiy</a>
+ */
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+@javax.persistence.Entity
+public class IgnoredEntity {
+    @Id
+    @GeneratedValue
+    private long id;
+    @Column
+    private String name;
+
+    public IgnoredEntity() {
+    }
+
+    public IgnoredEntity(String name) {
+        this.name = name;
+    }
+}

--- a/supplement/integration-testing/hibernate4-cache-over-mysql/src/test/resources/hibernate.cfg.xml
+++ b/supplement/integration-testing/hibernate4-cache-over-mysql/src/test/resources/hibernate.cfg.xml
@@ -10,6 +10,7 @@
         <property name="cache.region.factory_class">org.hibernate.cache.ehcache.EhCacheRegionFactory</property>
         <property name="cache.use_query_cache">true</property>
         <property name="cache.use_second_level_cache">true</property>
+        <mapping class="com.github.shyiko.rook.it.h4com.model.IgnoredEntity"/>
         <mapping class="com.github.shyiko.rook.it.h4com.model.RootEntity"/>
         <mapping class="com.github.shyiko.rook.it.h4com.model.OneToOneEntity"/>
         <mapping class="com.github.shyiko.rook.it.h4com.model.OneToManyEntity"/>

--- a/supplement/integration-testing/hibernate4-cache-over-mysql/src/test/resources/master-ehcache.xml
+++ b/supplement/integration-testing/hibernate4-cache-over-mysql/src/test/resources/master-ehcache.xml
@@ -11,6 +11,8 @@
 
     <cache name="com.github.shyiko.rook.it.h4com.model.RootEntity"
            maxEntriesLocalHeap="100" overflowToDisk="false" timeToLiveSeconds="120"/>
+    <cache name="com.github.shyiko.rook.it.h4com.model.IgnoredEntity"
+           maxEntriesLocalHeap="100" overflowToDisk="false" timeToLiveSeconds="120"/>
     <cache name="com.github.shyiko.rook.it.h4com.model.RootEntity.oneToManyEntities"
            maxEntriesLocalHeap="100" overflowToDisk="false" timeToLiveSeconds="120"/>
     <cache name="com.github.shyiko.rook.it.h4com.model.RootEntity.joinedOneToManyEntities"

--- a/supplement/integration-testing/hibernate4-cache-over-mysql/src/test/resources/master-sdb-ehcache.xml
+++ b/supplement/integration-testing/hibernate4-cache-over-mysql/src/test/resources/master-sdb-ehcache.xml
@@ -11,6 +11,8 @@
 
     <cache name="com.github.shyiko.rook.it.h4com.model.RootEntity"
            maxEntriesLocalHeap="100" overflowToDisk="false" timeToLiveSeconds="120"/>
+    <cache name="com.github.shyiko.rook.it.h4com.model.IgnoredEntity"
+           maxEntriesLocalHeap="100" overflowToDisk="false" timeToLiveSeconds="120"/>
     <cache name="com.github.shyiko.rook.it.h4com.model.RootEntity.oneToManyEntities"
            maxEntriesLocalHeap="100" overflowToDisk="false" timeToLiveSeconds="120"/>
     <cache name="com.github.shyiko.rook.it.h4com.model.RootEntity.joinedOneToManyEntities"

--- a/supplement/integration-testing/hibernate4-cache-over-mysql/src/test/resources/slave-ehcache.xml
+++ b/supplement/integration-testing/hibernate4-cache-over-mysql/src/test/resources/slave-ehcache.xml
@@ -11,6 +11,8 @@
 
     <cache name="com.github.shyiko.rook.it.h4com.model.RootEntity"
            maxEntriesLocalHeap="100" overflowToDisk="false" timeToLiveSeconds="120"/>
+    <cache name="com.github.shyiko.rook.it.h4com.model.IgnoredEntity"
+           maxEntriesLocalHeap="100" overflowToDisk="false" timeToLiveSeconds="120"/>
     <cache name="com.github.shyiko.rook.it.h4com.model.RootEntity.oneToManyEntities"
            maxEntriesLocalHeap="100" overflowToDisk="false" timeToLiveSeconds="120"/>
     <cache name="com.github.shyiko.rook.it.h4com.model.RootEntity.joinedOneToManyEntities"

--- a/supplement/integration-testing/hibernate4-cache-over-mysql/src/test/resources/slave-sdb-ehcache.xml
+++ b/supplement/integration-testing/hibernate4-cache-over-mysql/src/test/resources/slave-sdb-ehcache.xml
@@ -11,6 +11,8 @@
 
     <cache name="com.github.shyiko.rook.it.h4com.model.RootEntity"
            maxEntriesLocalHeap="100" overflowToDisk="false" timeToLiveSeconds="120"/>
+    <cache name="com.github.shyiko.rook.it.h4com.model.IgnoredEntity"
+           maxEntriesLocalHeap="100" overflowToDisk="false" timeToLiveSeconds="120"/>
     <cache name="com.github.shyiko.rook.it.h4com.model.RootEntity.oneToManyEntities"
            maxEntriesLocalHeap="100" overflowToDisk="false" timeToLiveSeconds="120"/>
     <cache name="com.github.shyiko.rook.it.h4com.model.RootEntity.joinedOneToManyEntities"


### PR DESCRIPTION
- optimized way to filter out early events from specific tables (e.g. `heartbeat` from pt-heartbeat package);
- ability to filter out events by origin server_id (e.g. don't process events generated by 'local' server)